### PR TITLE
Shift Spine On Page Turn for More Fluid Movement

### DIFF
--- a/examples/Three/flipbook3/FlipBook3DApplication.js
+++ b/examples/Three/flipbook3/FlipBook3DApplication.js
@@ -13,27 +13,25 @@ if (!window.requestAnimationFrame) {
     window.oRequestAnimationFrame ||
     window.msRequestAnimationFrame ||
     function( /* function FrameRequestCallback */ callback, /* DOMElement Element */ element ) {
-
-    window.setTimeout( callback, 1000 / 60 );
-
+        window.setTimeout(callback, 1000 / 60);
     };
 
     })();
 
 }
 
-var multx = 0.5*Math.PI,
+var multx = 0.5 * Math.PI,
     multy = -Math.PI,
     Sin = Math.sin,
     Cos = Math.cos,
 
     container, camera, scene, renderer, projector,
     targetRotationY = 0, targetRotationOnMouseDownY = 0, targetRotationX = 0, targetRotationOnMouseDownX = 0,
-    rad=700, mouse={x:0,y:0}, mouseX = 0, mouseXOnMouseDown = 0, mouseY = 0, mouseYOnMouseDown = 0,
+    rad=700, mouse={x:0, y:0}, mouseX = 0, mouseXOnMouseDown = 0, mouseY = 0, mouseYOnMouseDown = 0,
     mstack, bend,
     windowHalfX = window.innerWidth / 2, windowHalfY = window.innerHeight / 2,
     w,h,w2,h2,
-    book, pagew=300, pageh=pagew*10/7,
+    book, pagew = 300, pageh = pagew * 10 / 7,
     fl,fr
 ;
 
@@ -103,10 +101,10 @@ var self = {
         container = document.getElementById('container');
         w = window.innerWidth;
         h = window.innerHeight;
-        w2 = w/2; h2 = h/2;
-        container.style.width = String(w)+"px";
-        container.style.height = String(h)+"px";
-        container.style.marginTop = String(0.5*(window.innerHeight-h))+'px';
+        w2 = w / 2; h2 = h / 2;
+        container.style.width = String(w) + "px";
+        container.style.height = String(h) + "px";
+        container.style.marginTop = String(0.5 * (window.innerHeight - h)) + 'px';
 
         scene = new THREE.Scene();
         projector = new THREE.Projector();
@@ -138,17 +136,11 @@ var self = {
         // add flip controls
         fl = document.getElementById('flipleft');
         fl.addEventListener('click', function() {
-            var plen = book.pages.length,
-                pindex = plen-book.flippedright
-            ;
-            if (pindex >= 0 && pindex < plen) book.pages[pindex].flipLeft();
+            book.flipLeft();
         });
         fr = document.getElementById('flipright');
         fr.addEventListener('click', function() {
-            var plen = book.pages.length,
-                pindex = book.flippedleft-1
-            ;
-            if (pindex >= 0 && pindex < plen) book.pages[pindex].flipRight();
+            book.flipRight();
         });
 
         // start rendering


### PR DESCRIPTION
I really like the flippbook example and want to use it for a fun project. Beforehand, I feel it would be good to contribute back a little and get the example updated. I'll keep picking at this draft PR for a bit if that's cool. Comments and suggestions are welcome.

To start, I revised so that the "spine" moves with the pages so that more pages can be added and positioned without odd turning effects (e.g. page lifted up, flipped, then dropped down).

I also moved more page flipping control to the Book class with less of that in the app.

There was also an instance where the child Page class was calling a method on the parent Book class. Instead I called a callback from the child class that the parent could listen for.

Sample images show more clearly with a filter update (could be even clearer with less compressed images).

Pardon the line break conversion. Whitespace can be ignored when viewing via the sprocket/options to make it look much better. I can work to convert back to old `\r\n` format if needed.

I'll keep playing with it, updating to ES6 soon?